### PR TITLE
Dependencies should not lock us into Rails 3.1.0.rc2 anymore. Hopefully.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,9 +18,9 @@ Hoe.spec 'minitest-rails' do
   self.testlib      = :minitest
 
   extra_deps << ['minitest',      '~> 2.2']
-  extra_deps << ['railties',      '= 3.1.0.rc2']
-  extra_deps << ['activesupport', '= 3.1.0.rc2']
-  extra_deps << ['actionpack',    '= 3.1.0.rc2']
+  extra_deps << ['railties',      '>= 3.1.0.rc2']
+  extra_deps << ['activesupport', '>= 3.1.0.rc2']
+  extra_deps << ['actionpack',    '>= 3.1.0.rc2']
 end
 
 # vim: syntax=ruby


### PR DESCRIPTION
Requiring the dependencies of Rails 3.1.0.rc2 keep us from using the gem under Rails 3.1.0.rc3 and, presumably, any future releases.
