### PR TITLE
Scaffold generator uses 'setup' rather than 'before'

### DIFF
--- a/lib/generators/mini_test/scaffold/templates/controller_spec.rb
+++ b/lib/generators/mini_test/scaffold/templates/controller_spec.rb
@@ -2,7 +2,7 @@ require "minitest_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>ControllerTest < MiniTest::Rails::Controller
-  setup do
+  before do
     @<%= singular_table_name %> = <%= table_name %>(:one)
   end
 

--- a/lib/generators/mini_test/scaffold/templates/controller_test.rb
+++ b/lib/generators/mini_test/scaffold/templates/controller_test.rb
@@ -2,7 +2,7 @@ require "minitest_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>ControllerTest < MiniTest::Rails::Controller
-  setup do
+  before do
     @<%= singular_table_name %> = <%= table_name %>(:one)
   end
 


### PR DESCRIPTION
Fixes the issue in the Scaffold generator.  It uses 'setup' rather than 'before' - it was making my tests crash.
