### PR TITLE
Remove broken code from helper test's setup.

### DIFF
--- a/lib/generators/mini_test/helper/templates/helper_spec.rb
+++ b/lib/generators/mini_test/helper/templates/helper_spec.rb
@@ -1,11 +1,9 @@
 require "minitest_helper"
 
 class <%= class_name %>HelperTest < MiniTest::Rails::Helper
-  before do
-    @helper= <%= class_name %>Helper.new
-  end
 
   it "must be a real test" do
     flunk "Need real tests"
   end
+
 end


### PR DESCRIPTION
The generated helper tests were trying to instantiate the helper, which is a module.
