### PR TITLE
Allow use with Rails 3.x, not just 3.1.x.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ Hoe.spec 'minitest-rails' do
   self.testlib      = :minitest
 
   extra_deps << ['minitest',  '~> 2.2']
-  extra_deps << ['rails',     '~> 3.1.0']
+  extra_deps << ['rails',     '~> 3.1']
 end
 
 # vim: syntax=ruby


### PR DESCRIPTION
I'm not sure if there are more patches required for this, as I can't install the gem from the branch as the project uses hoe. Hmmm.

I made the patch with that in mind though, so thought I should probably submit the pr anyway, if for no other reason than to point out the friction that comes with hoe…

See blowmage/minitest-rails#22.
