### PR TITLE
Fixed: undefined method `application' for MiniTest::Rails:Module

### DIFF
--- a/lib/minitest/rails/controller.rb
+++ b/lib/minitest/rails/controller.rb
@@ -8,9 +8,6 @@ module MiniTest
     class Controller < Spec
       include ActiveSupport::Testing::SetupAndTeardown
       include ActionController::TestCase::Behavior
-      before do
-        @routes = Rails.application.routes
-      end
     end
   end
 end


### PR DESCRIPTION
Running controller tests with Rails 3.2.2 on Ruby 1.9.3 resulted in:

NoMethodError: undefined method `application' for MiniTest::Rails:Module
    /Users/joachim/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activesupport-3.2.2/lib/active_support/testing/setup_and_teardown.rb:35:in`block in run'
    /Users/joachim/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:425:in `_run__3728210640247004450__setup__2269744947180433434__callbacks'
    /Users/joachim/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:405:in`__run_callback'
    /Users/joachim/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:385:in `_run_setup_callbacks'
    /Users/joachim/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:81:in`run_callbacks'
    /Users/joachim/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activesupport-3.2.2/lib/active_support/testing/setup_and_teardown.rb:34:in `run'

I removed the call to Rails.application.routes from the controller task. It seemed unnecessary since @routes is already set in the minitest_helper.
