### PR TITLE
Set @routes correctly

### DIFF
--- a/lib/minitest/rails/controller.rb
+++ b/lib/minitest/rails/controller.rb
@@ -9,7 +9,7 @@ module MiniTest
       include ActiveSupport::Testing::SetupAndTeardown
       include ActionController::TestCase::Behavior
       before do
-        @routes = Rails.application.routes
+        @routes = ::Rails.application.routes
       end
     end
   end


### PR DESCRIPTION
Sorry, shitty commit message. Thinking about it though, since the generator generates code to set @routes, maybe it makes sense to remove this from MiniTest::Rails::Controller altogether.
