### PR TITLE
Replace `superclass` with `<` notation to detect class type

### DIFF
--- a/lib/generators/minitest/install/templates/test/minitest_helper.rb
+++ b/lib/generators/minitest/install/templates/test/minitest_helper.rb
@@ -30,7 +30,7 @@ class Minitest::Rails::Model
 end
 
 Minitest::Spec.register_spec_type(Minitest::Rails::Model) do |desc|
-  desc.respond_to?(:superclass) && desc.superclass == ActiveRecord::Base
+  desc < ActiveRecord::Base
 end
 
 class Minitest::Rails::Controller
@@ -56,6 +56,6 @@ class Minitest::Rails::Mailer
 end
 
 Minitest::Spec.register_spec_type(Minitest::Rails::Mailer) do |desc|
-  desc.respond_to?(:superclass) && desc.superclass == ActionMailer::Base
+  desc < ActionMailer::Base
 end
 


### PR DESCRIPTION
`superclass` is not ideal because it fails on classes of following implementations:
- Classes that implement abstract AR baseclass

However, '<' is always a reliable solution, it works regardlessly. :)
