### PR TITLE
Fix minitest describe method override

### DIFF
--- a/lib/minitest/rails/active_support.rb
+++ b/lib/minitest/rails/active_support.rb
@@ -48,6 +48,10 @@ module MiniTest
           :sorted
         end
 
+        def describe(*args, &block)
+          Kernel.describe(args, block)
+        end
+
         include ::ActiveSupport::Testing::SetupAndTeardown
         include ::ActiveSupport::Testing::Assertions
         include ::ActiveSupport::Testing::Deprecation


### PR DESCRIPTION
This will close #48

It may not be the best way to handle this, I can think that :
- Minitest could define `describe` in [MiniTest::Spec](https://github.com/seattlerb/minitest/blob/master/lib/minitest/spec.rb)
- Rails may check if `Kernel.describe` is defined in [ActiveSupport::Testing::Declarative](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/testing/declarative.rb)

I do not know what would be the best way, the question should probably asked to people from theses projects. For now, it's working with this.
