### PR TITLE
Load ActionMailer only if it is also used.

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -4,7 +4,7 @@ abort("Abort testing: Your Rails environment is running in production mode!") if
 
 require "minitest/rails/active_support"
 require "minitest/rails/action_controller"
-require "minitest/rails/action_view"
+require "minitest/rails/action_view" if defined?(ActionMailer::Base)
 require "minitest/rails/action_mailer"
 require "minitest/rails/action_dispatch"
 


### PR DESCRIPTION
I have Rails app which will never use `ActionMailer`, so I excluded `ActionMailer` at all:

``` ruby
require 'active_record/railtie'
require 'action_controller/railtie'
# require 'action_mailer/railtie'
# require 'active_resource/railtie'
# require 'rails/test_unit/railtie'
require 'sprockets/railtie'
```

This commit fixes specs failing with `uninitialized constant ActionMailer::TestCase::Behavior::TestHelper (NameError)`.
