### PR TITLE
improve naming conventions for --spec option:

### DIFF
--- a/lib/generators/mini_test/controller/controller_generator.rb
+++ b/lib/generators/mini_test/controller/controller_generator.rb
@@ -9,12 +9,12 @@ module MiniTest
       check_class_collision :suffix => "ControllerTest"
 
       def create_test_files
-        if options[:spec]
-          template "controller_spec.rb", File.join("test/controllers", class_path, "#{file_name}_controller_test.rb")
-        else
-          template "controller_test.rb", File.join("test/controllers", class_path, "#{file_name}_controller_test.rb")
-        end
+        format = options.spec? ? "spec" : "test"
+        template "controller_#{format}.rb", File.join(
+          format, "controllers", class_path, "#{file_name}_controller_#{format}.rb"
+        )
       end
+
     end
   end
 end

--- a/lib/generators/mini_test/controller/templates/controller_spec.rb
+++ b/lib/generators/mini_test/controller/templates/controller_spec.rb
@@ -1,4 +1,4 @@
-require "minitest_helper"
+require "spec_helper"
 
 <% module_namespacing do -%>
 describe <%= class_name %>Controller do

--- a/lib/generators/mini_test/helper/helper_generator.rb
+++ b/lib/generators/mini_test/helper/helper_generator.rb
@@ -8,12 +8,12 @@ module MiniTest
       check_class_collision :suffix => "HelperTest"
 
       def create_test_files
-        if options[:spec]
-          template "helper_spec.rb", File.join("test/helpers", class_path, "#{file_name}_helper_test.rb")
-        else
-          template "helper_test.rb", File.join("test/helpers", class_path, "#{file_name}_helper_test.rb")
-        end
+        format = options.spec? ? "spec" : "test"
+        template "helper_#{format}.rb", File.join(
+          format, "helpers", class_path, "#{file_name}_helper_#{format}.rb"
+        )
       end
+
     end
   end
 end

--- a/lib/generators/mini_test/helper/templates/helper_spec.rb
+++ b/lib/generators/mini_test/helper/templates/helper_spec.rb
@@ -1,4 +1,4 @@
-require "minitest_helper"
+require "spec_helper"
 
 describe <%= class_name %>Helper do
 

--- a/lib/generators/mini_test/install/install_generator.rb
+++ b/lib/generators/mini_test/install/install_generator.rb
@@ -3,20 +3,17 @@ require 'rails/generators'
 module MiniTest
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path("../templates", __FILE__)
+      class_option :spec, :type => :boolean, :default => false
 
-      desc <<DESC
-Description:
-    Copy minitest files to your application.
-DESC
-
-      def self.source_root
-        @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+      desc "Copy minitest files to your application."
+      def install
+        if options.spec?
+          template "test/minitest_helper.rb", "spec/spec_helper.rb"
+        else
+          directory "test"
+        end
       end
-
-      def copy_minitest_files
-        directory 'test'
-      end
-
     end
   end
 end

--- a/lib/generators/mini_test/integration/integration_generator.rb
+++ b/lib/generators/mini_test/integration/integration_generator.rb
@@ -8,12 +8,12 @@ module MiniTest
       check_class_collision :suffix => "Test"
 
       def create_test_files
-        if options[:spec]
-          template 'integration_spec.rb', File.join('test/acceptance', class_path, "#{file_name}_test.rb")
-        else
-          template 'integration_test.rb', File.join('test/acceptance', class_path, "#{file_name}_test.rb")
-        end
+        format = options.spec? ? "spec" : "test"
+        template "integration_#{format}.rb", File.join(
+          format, "acceptance", class_path, "#{file_name}_#{format}.rb"
+        )
       end
+
     end
   end
 end

--- a/lib/generators/mini_test/integration/templates/integration_spec.rb
+++ b/lib/generators/mini_test/integration/templates/integration_spec.rb
@@ -1,4 +1,4 @@
-require "minitest_helper"
+require "spec_helper"
 
 # To be handled correctly this spec must end with "Acceptance Test"
 describe "<%= class_name %> Acceptance Test" do

--- a/lib/generators/mini_test/mailer/mailer_generator.rb
+++ b/lib/generators/mini_test/mailer/mailer_generator.rb
@@ -9,12 +9,10 @@ module MiniTest
       check_class_collision :suffix => "MailerTest"
 
       def create_test_files
-        if options[:spec]
-          template "mailer_spec.rb", "test/mailers/#{file_name}_test.rb"
-        else
-          template "mailer_test.rb", "test/mailers/#{file_name}_test.rb"
-        end
+        format = options.spec? ? "spec" : "test"
+        template "mailer_#{format}.rb", "#{format}/mailers/#{file_name}_#{format}.rb"
       end
+
     end
   end
 end

--- a/lib/generators/mini_test/mailer/templates/mailer_spec.rb
+++ b/lib/generators/mini_test/mailer/templates/mailer_spec.rb
@@ -1,4 +1,4 @@
-require "minitest_helper"
+require "spec_helper"
 
 <% module_namespacing do -%>
 describe <%= class_name %> do

--- a/lib/generators/mini_test/model/model_generator.rb
+++ b/lib/generators/mini_test/model/model_generator.rb
@@ -10,19 +10,21 @@ module MiniTest
       check_class_collision :suffix => "Test"
 
       def create_test_file
-        if options[:spec]
-          template "model_spec.rb", "test/models/#{file_name}_test.rb"
-        else
-          template "model_test.rb", "test/models/#{file_name}_test.rb"
-        end
+        template "model_#{format}.rb", "#{format}/models/#{file_name}_#{format}.rb"
       end
 
       hook_for :fixture_replacement
 
       def create_fixture_file
         if options[:fixture] && options[:fixture_replacement].nil?
-          template "fixtures.yml", "test/fixtures/#{plural_file_name}.yml"
+          template "fixtures.yml", "#{format}/fixtures/#{plural_file_name}.yml"
         end
+      end
+
+      private
+
+      def format
+        options.spec? ? "spec" : "test"
       end
     end
   end

--- a/lib/generators/mini_test/model/templates/model_spec.rb
+++ b/lib/generators/mini_test/model/templates/model_spec.rb
@@ -1,4 +1,4 @@
-require "minitest_helper"
+require "spec_helper"
 
 <% module_namespacing do -%>
 describe <%= class_name %> do

--- a/lib/generators/mini_test/scaffold/scaffold_generator.rb
+++ b/lib/generators/mini_test/scaffold/scaffold_generator.rb
@@ -11,18 +11,14 @@ module MiniTest
       check_class_collision :suffix => "ControllerTest"
 
       def create_test_files
-        if options[:spec]
-          template "controller_spec.rb",
-                   File.join("test/controllers",
-                             class_path,
-                             "#{controller_file_name}_controller_test.rb")
-        else
-          template "controller_test.rb",
-                   File.join("test/controllers",
-                             class_path,
-                             "#{controller_file_name}_controller_test.rb")
-        end
+        format = options.spec? ? "spec" : "test"
+
+        template "controller_#{format}.rb", File.join(
+          format, "controllers", class_path,
+          "#{controller_file_name}_controller_#{format}.rb"
+        )
       end
+
     end
   end
 end

--- a/lib/generators/mini_test/scaffold/templates/controller_spec.rb
+++ b/lib/generators/mini_test/scaffold/templates/controller_spec.rb
@@ -1,4 +1,4 @@
-require "minitest_helper"
+require "spec_helper"
 
 <% module_namespacing do -%>
 describe <%= controller_class_name %>Controller do

--- a/test/generators/test_controller_generator.rb
+++ b/test/generators/test_controller_generator.rb
@@ -50,9 +50,9 @@ class TestControllerGenerator < MiniTest::Unit::TestCase
     out, err = capture_io do
       MiniTest::Generators::ControllerGenerator.start ["user", "--spec"]
     end
-    assert_match(/create  test\/controllers\/user_controller_test.rb/m, out)
-    assert File.exists? "test/controllers/user_controller_test.rb"
-    contents = File.read "test/controllers/user_controller_test.rb"
+    assert_match(/create  spec\/controllers\/user_controller_spec.rb/m, out)
+    assert File.exists? "spec/controllers/user_controller_spec.rb"
+    contents = File.read "spec/controllers/user_controller_spec.rb"
     assert_match(/describe UserController do/m, contents)
   end
 
@@ -61,9 +61,9 @@ class TestControllerGenerator < MiniTest::Unit::TestCase
       out, err = capture_io do
         MiniTest::Generators::ControllerGenerator.start ["admin/user", "--spec"]
       end
-      assert_match(/create  test\/controllers\/admin\/user_controller_test.rb/m, out)
-      assert File.exists? "test/controllers/admin/user_controller_test.rb"
-      contents = File.read "test/controllers/admin/user_controller_test.rb"
+      assert_match(/create  spec\/controllers\/admin\/user_controller_spec.rb/m, out)
+      assert File.exists? "spec/controllers/admin/user_controller_spec.rb"
+      contents = File.read "spec/controllers/admin/user_controller_spec.rb"
       assert_match(/describe Admin::UserController do/m, contents)
     end
   end

--- a/test/generators/test_helper_generator.rb
+++ b/test/generators/test_helper_generator.rb
@@ -50,9 +50,9 @@ class TestHelperGenerator < MiniTest::Unit::TestCase
     out, err = capture_io do
       MiniTest::Generators::HelperGenerator.start ["user", "--spec"]
     end
-    assert_match(/create  test\/helpers\/user_helper_test.rb/m, out)
-    assert File.exists? "test/helpers/user_helper_test.rb"
-    contents = File.read "test/helpers/user_helper_test.rb"
+    assert_match(/create  spec\/helpers\/user_helper_spec.rb/m, out)
+    assert File.exists? "spec/helpers/user_helper_spec.rb"
+    contents = File.read "spec/helpers/user_helper_spec.rb"
     assert_match(/describe UserHelper do/m, contents)
   end
 
@@ -60,9 +60,9 @@ class TestHelperGenerator < MiniTest::Unit::TestCase
     out, err = capture_io do
       MiniTest::Generators::HelperGenerator.start ["admin/user", "--spec"]
     end
-    assert_match(/create  test\/helpers\/admin\/user_helper_test.rb/m, out)
-    assert File.exists? "test/helpers/admin/user_helper_test.rb"
-    contents = File.read "test/helpers/admin/user_helper_test.rb"
+    assert_match(/create  spec\/helpers\/admin\/user_helper_spec.rb/m, out)
+    assert File.exists? "spec/helpers/admin/user_helper_spec.rb"
+    contents = File.read "spec/helpers/admin/user_helper_spec.rb"
     assert_match(/describe Admin::UserHelper do/m, contents)
   end
 

--- a/test/generators/test_mailer_generator.rb
+++ b/test/generators/test_mailer_generator.rb
@@ -40,9 +40,9 @@ class TestMailerGenerator < MiniTest::Unit::TestCase
     out, err = capture_io do
       MiniTest::Generators::MailerGenerator.start ["notification", "welcome", "--spec"]
     end
-    assert_match(/create  test\/mailers\/notification_test.rb/m, out)
-    assert File.exists? "test/mailers/notification_test.rb"
-    contents = File.read "test/mailers/notification_test.rb"
+    assert_match(/create  spec\/mailers\/notification_spec.rb/m, out)
+    assert File.exists? "spec/mailers/notification_spec.rb"
+    contents = File.read "spec/mailers/notification_spec.rb"
     assert_match(/describe Notification do/m, contents)
   end
 end

--- a/test/generators/test_model_generator.rb
+++ b/test/generators/test_model_generator.rb
@@ -40,10 +40,10 @@ class TestModelGenerator < MiniTest::Unit::TestCase
     out, err = capture_io do
       MiniTest::Generators::ModelGenerator.start ["user", "--spec"]
     end
-    assert_match(/create  test\/models\/user_test.rb/m, out)
-    assert File.exists? "test/models/user_test.rb"
-    assert File.exists? "test/fixtures/users.yml"
-    contents = File.read "test/models/user_test.rb"
+    assert_match(/create  spec\/models\/user_spec.rb/m, out)
+    assert File.exists? "spec/models/user_spec.rb"
+    assert File.exists? "spec/fixtures/users.yml"
+    contents = File.read "spec/models/user_spec.rb"
     assert_match(/describe User do/m, contents)
   end
 

--- a/test/generators/test_scaffold_generator.rb
+++ b/test/generators/test_scaffold_generator.rb
@@ -40,9 +40,9 @@ class TestScaffoldGenerator < MiniTest::Unit::TestCase
     out, err = capture_io do
       MiniTest::Generators::ScaffoldGenerator.start ["user", "--spec"]
     end
-    assert_match(/create  test\/controllers\/users_controller_test.rb/m, out)
-    assert File.exists? "test/controllers/users_controller_test.rb"
-    contents = File.read "test/controllers/users_controller_test.rb"
+    assert_match(/create  spec\/controllers\/users_controller_spec.rb/m, out)
+    assert File.exists? "spec/controllers/users_controller_spec.rb"
+    contents = File.read "spec/controllers/users_controller_spec.rb"
     assert_match(/describe UsersController do/m, contents)
   end
 end


### PR DESCRIPTION
- use spec/ vs. test/ directory structure
- name helper 'spec_helper' vs. 'minitest_helper'
- created filenames end with '_spec' vs '_test'
