### PR TITLE
description strings should match MiniTest::Spec and not brake the tests

### DIFF
--- a/lib/minitest/rails/active_support.rb
+++ b/lib/minitest/rails/active_support.rb
@@ -27,7 +27,7 @@ module MiniTest
         if defined?(ActiveRecord::Base)
           # Use AS::TestCase for the base class when describing a model
           register_spec_type(self) do |desc|
-            desc < ActiveRecord::Base
+            desc < ActiveRecord::Base unless desc.is_a? String
           end
         end
 

--- a/test/rails/test_active_record_spec_type.rb
+++ b/test/rails/test_active_record_spec_type.rb
@@ -1,0 +1,16 @@
+require "minitest/autorun"
+require "active_record"
+require "minitest-rails"
+require "minitest/rails/active_support"
+
+class TestActiveRecordSpecType < MiniTest::Unit::TestCase
+  class AModel < ActiveRecord::Base; end
+
+  def test_spec_type_resolves_for_matching_strings
+    assert_equal MiniTest::Spec.spec_type(AModel), MiniTest::Rails::ActiveSupport::TestCase
+  end
+
+  def test_string_descriptions_continue_to_match_minitest_spec
+    assert_equal MiniTest::Spec.spec_type('some string'), MiniTest::Spec
+  end
+end


### PR DESCRIPTION
When the description is a String it results in trying to match it ActiveRecord::Base which results in

```
gems/minitest-rails-0.1.3/lib/minitest/rails/active_support.rb:30:in `<': comparison of String with Class failed (ArgumentError)
        from gems/minitest-rails-0.1.3/lib/minitest/rails/active_support.rb:30:in `block in <class:TestCase>'
```

``` ruby
describe 'Some string' do
  it 'routs to ' do
    assert true
  end
end
```
