### PR TITLE
Fix for issue #75 and missing host exception

### DIFF
--- a/lib/minitest/rails/action_dispatch.rb
+++ b/lib/minitest/rails/action_dispatch.rb
@@ -26,6 +26,11 @@ module MiniTest
         def app
           super || ::ActionDispatch::IntegrationTest.app
         end
+        
+        def url_options
+          reset! unless integration_session
+          integration_session.url_options
+        end
 
         # Register by name
         register_spec_type(/Acceptance ?Test\z/i, self)


### PR DESCRIPTION
This commit fixes the issue I described in #75. The problem was that it tried to get the `application` from the Rails constant defined in your module rather than the top level Rails constant.
