### PR TITLE
Update controller scaffold templates

### DIFF
--- a/lib/generators/mini_test/scaffold/scaffold_generator.rb
+++ b/lib/generators/mini_test/scaffold/scaffold_generator.rb
@@ -10,6 +10,8 @@ module MiniTest
 
       check_class_collision :suffix => "ControllerTest"
 
+      argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
+
       def create_test_files
         if options[:spec]
           template "controller_spec.rb",
@@ -22,6 +24,19 @@ module MiniTest
                              class_path,
                              "#{controller_file_name}_controller_test.rb")
         end
+      end
+
+      def accessible_attributes
+        attributes.reject(&:reference?)
+      end
+
+      def attributes_hash
+        return if accessible_attributes.empty?
+
+        accessible_attributes.map do |a|
+          name = a.name
+          key_value name, "@#{singular_table_name}.#{name}"
+        end.sort.join(', ')
       end
     end
   end

--- a/lib/generators/mini_test/scaffold/templates/controller_spec.rb
+++ b/lib/generators/mini_test/scaffold/templates/controller_spec.rb
@@ -4,7 +4,7 @@ require "minitest_helper"
 describe <%= controller_class_name %>Controller do
 
   before do
-    @<%= singular_table_name %> = <%= class_name %>.new
+    @<%= singular_table_name %> = <%= table_name %>(:one)
   end
 
   it "must get index" do
@@ -20,30 +20,30 @@ describe <%= controller_class_name %>Controller do
 
   it "must create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
-      post :create, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+      post :create, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
     end
 
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   it "must show <%= singular_table_name %>" do
-    get :show, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+    get :show, <%= key_value :id, "@#{singular_table_name}" %>
     assert_response :success
   end
 
   it "must get edit" do
-    get :edit, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+    get :edit, <%= key_value :id, "@#{singular_table_name}" %>
     assert_response :success
   end
 
   it "must update <%= singular_table_name %>" do
-    put :update, <%= key_value :id, "@#{singular_table_name}.to_param" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+    put :update, <%= key_value :id, "@#{singular_table_name}" %>, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   it "must destroy <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count', -1) do
-      delete :destroy, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+      delete :destroy, <%= key_value :id, "@#{singular_table_name}" %>
     end
 
     assert_redirected_to <%= index_helper %>_path

--- a/lib/generators/mini_test/scaffold/templates/controller_test.rb
+++ b/lib/generators/mini_test/scaffold/templates/controller_test.rb
@@ -4,7 +4,7 @@ require "minitest_helper"
 class <%= controller_class_name %>ControllerTest < MiniTest::Rails::ActionController::TestCase
 
   before do
-    @<%= singular_table_name %> = <%= class_name %>.new
+    @<%= singular_table_name %> = <%= table_name %>(:one)
   end
 
   def test_index
@@ -20,30 +20,30 @@ class <%= controller_class_name %>ControllerTest < MiniTest::Rails::ActionContro
 
   def test_create
     assert_difference('<%= class_name %>.count') do
-      post :create, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+      post :create, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
     end
 
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   def test_show
-    get :show, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+    get :show, <%= key_value :id, "@#{singular_table_name}" %>
     assert_response :success
   end
 
   def test_edit
-    get :edit, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+    get :edit, <%= key_value :id, "@#{singular_table_name}" %>
     assert_response :success
   end
 
   def test_update
-    put :update, <%= key_value :id, "@#{singular_table_name}.to_param" %>, <%= key_value singular_table_name, "@#{singular_table_name}.attributes" %>
+    put :update, <%= key_value :id, "@#{singular_table_name}" %>, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
     assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   def test_destroy
     assert_difference('<%= class_name %>.count', -1) do
-      delete :destroy, <%= key_value :id, "@#{singular_table_name}.to_param" %>
+      delete :destroy, <%= key_value :id, "@#{singular_table_name}" %>
     end
 
     assert_redirected_to <%= index_helper %>_path


### PR DESCRIPTION
Previously, one would get mass assignment and route errors.  Now all tests pass.  Brought in some code from rails/master for the mass assignment issue.

Tested with rails 3.2.8 clean app with vanilla install of minitest-rails per github docs.

test loop, fwiw:

alias br='bundle exec rake'

bundle; br db:drop:all; br db:create:all; rails d scaffold user name; rails g scaffold user name; br db:migrate; br test

rails d scaffold user name # reset for spec loop

bundle; br db:drop:all; br db:create:all; rails d scaffold user name --spec; rails g scaffold user name --spec; br db:migrate; br test
