### PR TITLE
Override ActiveModel::TestCase too

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -6,6 +6,7 @@ require "minitest/rails/active_support"
 require "minitest/rails/action_controller"
 require "minitest/rails/action_view"
 require "minitest/rails/action_mailer" if defined? ActionMailer
+require "minitest/rails/active_model"
 require "minitest/rails/action_dispatch"
 
 # Enable turn if it is available
@@ -22,6 +23,7 @@ module MiniTest
         ::ActionController.const_set :TestCase,        MiniTest::Rails::ActionController::TestCase
         ::ActionView.const_set       :TestCase,        MiniTest::Rails::ActionView::TestCase
         ::ActionMailer.const_set     :TestCase,        MiniTest::Rails::ActionMailer::TestCase if defined? ActionMailer
+        ::ActiveModel.const_set      :TestCase,        MiniTest::Rails::ActiveModel::TestCase
         ::ActionDispatch.const_set   :IntegrationTest, MiniTest::Rails::ActionDispatch::IntegrationTest
       end
     end

--- a/lib/minitest/rails/active_model.rb
+++ b/lib/minitest/rails/active_model.rb
@@ -1,0 +1,11 @@
+require "minitest/rails/active_support"
+require "active_model/test_case"
+
+module MiniTest
+  module Rails
+    module ActiveModel
+      class TestCase < MiniTest::Rails::ActiveSupport::TestCase
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a `MiniTest::Rails::ActiveModel::TestCase` class which contains no code but inherits from `MiniTest::Rails::ActiveSupport::TestCase` like other Rails test cases using this gem.

The reason I had to use this is because `#setup` and `#teardown` were not supported in unit tests. Easy to fix, just add `include ActiveSupport::Testing::SetupAndTeardown` and be done with it! Wrong! Adding this line in `class MiniTest::Unit::TestCase` makes unit tests work, but causes `Stack level too deep` errors for other types of test.

So, with these changes, `ActiveModel::TestCase` tests behave like other tests.

Hoping to get feedback on this since I’m not 100% familiar with `Minitest` structure and/or `ActiveModel::TestCase`, so there might be a simpler way of doing it.

Thanks!
