### PR TITLE
Allow "Widget\s?Acceptance" and "Widget\?Integration" too.

### DIFF
--- a/lib/minitest/rails/action_dispatch.rb
+++ b/lib/minitest/rails/action_dispatch.rb
@@ -33,8 +33,7 @@ module MiniTest
         end
 
         # Register by name
-        register_spec_type(/Acceptance ?Test\z/i, self)
-        register_spec_type(/Integration ?Test\z/i, self)
+        register_spec_type(Regexp.union(/Acceptance( ?Test)?\z/i, /Integration( ?Test)?\z/i), self)
       end
     end
   end

--- a/test/rails/action_dispatch/test_spec_type.rb
+++ b/test/rails/action_dispatch/test_spec_type.rb
@@ -15,9 +15,13 @@ class TestActionDispatchSpecType < MiniTest::Unit::TestCase
   def test_spec_type_resolves_for_matching_acceptance_strings
     assert_dispatch MiniTest::Spec.spec_type("WidgetAcceptanceTest")
     assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance Test")
+    assert_dispatch MiniTest::Spec.spec_type("WidgetAcceptance")
+    assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance")
     # And is not case sensitive
     assert_dispatch MiniTest::Spec.spec_type("widgetacceptancetest")
     assert_dispatch MiniTest::Spec.spec_type("widget acceptance test")
+    assert_dispatch MiniTest::Spec.spec_type("widgetacceptance")
+    assert_dispatch MiniTest::Spec.spec_type("widget acceptance")
   end
 
   def test_spec_type_wont_match_non_space_characters_acceptance
@@ -32,9 +36,13 @@ class TestActionDispatchSpecType < MiniTest::Unit::TestCase
   def test_spec_type_resolves_for_matching_integration_strings
     assert_dispatch MiniTest::Spec.spec_type("WidgetIntegrationTest")
     assert_dispatch MiniTest::Spec.spec_type("Widget Integration Test")
+    assert_dispatch MiniTest::Spec.spec_type("WidgetIntegration")
+    assert_dispatch MiniTest::Spec.spec_type("Widget Integration")
     # And is not case sensitive
     assert_dispatch MiniTest::Spec.spec_type("widgetintegrationtest")
     assert_dispatch MiniTest::Spec.spec_type("widget integration test")
+    assert_dispatch MiniTest::Spec.spec_type("widgetintegration")
+    assert_dispatch MiniTest::Spec.spec_type("widget integration")
   end
 
   def test_spec_type_wont_match_non_space_characters_integration


### PR DESCRIPTION
Forcing me to use **Acceptance Test** when using the word **specs** every else feels a little be weird. 
This commit fixes this and allows me to use **Bla Acceptance** and **Bla Integration**! Hurray! :)
