### PR TITLE
Avoid deprecation warning in Mocha 0.13.0.

### DIFF
--- a/lib/minitest/rails/mochaing.rb
+++ b/lib/minitest/rails/mochaing.rb
@@ -2,7 +2,7 @@ begin
   require 'active_support/testing/mochaing'
 rescue LoadError
   begin
-    silence_warnings { require 'mocha' }
+    silence_warnings { require 'mocha/setup' }
   rescue LoadError
     # Fake Mocha::ExpectationError so we can rescue it in #run. Bleh.
     Object.const_set :Mocha, Module.new


### PR DESCRIPTION
I'm not entirely sure why this code is duplicated from ActiveSupport,
but this deprecation warning has been fixed in 3-2-stable [1] and in
master [2].

[1] https://github.com/rails/rails/pull/8200
[2] https://github.com/rails/rails/pull/8180
