### PR TITLE
Add case sensitivity on spec type strings.

### DIFF
--- a/lib/minitest/rails/action_controller.rb
+++ b/lib/minitest/rails/action_controller.rb
@@ -11,7 +11,7 @@ module MiniTest
         register_spec_type(self) do |desc|
           desc < ::ActionController::Base if desc.is_a?(Class)
         end
-        register_spec_type(/Controller( ?Test)?\z/i, self)
+        register_spec_type(/Controller( ?Test)?\z/, self)
 
         include ::ActionController::TestCase::Behavior
 

--- a/lib/minitest/rails/action_dispatch.rb
+++ b/lib/minitest/rails/action_dispatch.rb
@@ -26,14 +26,14 @@ module MiniTest
         def app
           super || ::ActionDispatch::IntegrationTest.app
         end
-        
+
         def url_options
           reset! unless integration_session
           integration_session.url_options
         end
 
         # Register by name
-        register_spec_type(/(Acceptance|Integration)( ?Test)?\z/i, self)
+        register_spec_type(/(Acceptance|Integration)( ?Test)?\z/, self)
       end
     end
   end

--- a/lib/minitest/rails/action_mailer.rb
+++ b/lib/minitest/rails/action_mailer.rb
@@ -9,7 +9,7 @@ module MiniTest
         register_spec_type(self) do |desc|
           desc < ::ActionMailer::Base if desc.is_a?(Class)
         end
-        register_spec_type(/Mailer( ?Test)?\z/i, self)
+        register_spec_type(/Mailer( ?Test)?\z/, self)
 
         include ::ActionMailer::TestCase::Behavior
 

--- a/lib/minitest/rails/action_view.rb
+++ b/lib/minitest/rails/action_view.rb
@@ -8,7 +8,7 @@ module MiniTest
         TestController = ::ActionView::TestCase::TestController
 
         # Use AV::TestCase for the base class for helpers and views
-        register_spec_type(/(Helper|View)( ?Test)?\z/i, self)
+        register_spec_type(/(Helper|View)( ?Test)?\z/, self)
 
         include ::ActionView::TestCase::Behavior
 

--- a/test/rails/action_controller/test_spec_type.rb
+++ b/test/rails/action_controller/test_spec_type.rb
@@ -25,10 +25,6 @@ class TestApplicationControllerSpecType < MiniTest::Unit::TestCase
     assert_controller MiniTest::Spec.spec_type("WidgetController")
     assert_controller MiniTest::Spec.spec_type("WidgetControllerTest")
     assert_controller MiniTest::Spec.spec_type("Widget Controller Test")
-    # And is not case sensitive
-    assert_controller MiniTest::Spec.spec_type("widgetcontroller")
-    assert_controller MiniTest::Spec.spec_type("widgetcontrollertest")
-    assert_controller MiniTest::Spec.spec_type("widget controller test")
   end
 
   def test_spec_type_wont_match_non_space_characters
@@ -37,5 +33,11 @@ class TestApplicationControllerSpecType < MiniTest::Unit::TestCase
     refute_controller MiniTest::Spec.spec_type("Widget Controller\nTest")
     refute_controller MiniTest::Spec.spec_type("Widget Controller\fTest")
     refute_controller MiniTest::Spec.spec_type("Widget ControllerXTest")
+  end
+
+  def test_spec_type_wont_match_non_acceptance_strings
+    refute_controller MiniTest::Spec.spec_type("FinancialControllerAddress")
+    refute_controller MiniTest::Spec.spec_type("FinancialControllerAddressTest")
+    refute_controller MiniTest::Spec.spec_type("FinancialController Address Test")
   end
 end

--- a/test/rails/action_dispatch/test_spec_type.rb
+++ b/test/rails/action_dispatch/test_spec_type.rb
@@ -17,20 +17,11 @@ class TestActionDispatchSpecType < MiniTest::Unit::TestCase
     assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance Test")
     assert_dispatch MiniTest::Spec.spec_type("WidgetAcceptance")
     assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance")
-    # And is not case sensitive
-    assert_dispatch MiniTest::Spec.spec_type("widgetacceptancetest")
-    assert_dispatch MiniTest::Spec.spec_type("widget acceptance test")
-    assert_dispatch MiniTest::Spec.spec_type("widgetacceptance")
-    assert_dispatch MiniTest::Spec.spec_type("widget acceptance")
   end
 
   def test_spec_type_wont_match_non_space_characters_acceptance
     refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\tTest")
     refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\rTest")
-    # TODO: Update regex so that new lines don't match.
-    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\nTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\fTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget AcceptanceXTest")
   end
 
   def test_spec_type_resolves_for_matching_integration_strings
@@ -38,11 +29,6 @@ class TestActionDispatchSpecType < MiniTest::Unit::TestCase
     assert_dispatch MiniTest::Spec.spec_type("Widget Integration Test")
     assert_dispatch MiniTest::Spec.spec_type("WidgetIntegration")
     assert_dispatch MiniTest::Spec.spec_type("Widget Integration")
-    # And is not case sensitive
-    assert_dispatch MiniTest::Spec.spec_type("widgetintegrationtest")
-    assert_dispatch MiniTest::Spec.spec_type("widget integration test")
-    assert_dispatch MiniTest::Spec.spec_type("widgetintegration")
-    assert_dispatch MiniTest::Spec.spec_type("widget integration")
   end
 
   def test_spec_type_wont_match_non_space_characters_integration
@@ -52,5 +38,18 @@ class TestActionDispatchSpecType < MiniTest::Unit::TestCase
     refute_equal MiniTest::Spec.spec_type("Widget Integration\nTest"), MiniTest::Rails::ActionDispatch::IntegrationTest
     refute_equal MiniTest::Spec.spec_type("Widget Integration\fTest"), MiniTest::Rails::ActionDispatch::IntegrationTest
     refute_equal MiniTest::Spec.spec_type("Widget IntegrationXTest"),  MiniTest::Rails::ActionDispatch::IntegrationTest
+  end
+
+  def test_spec_type_wont_match_non_acceptance_strings
+    refute_dispatch MiniTest::Spec.spec_type("AcceptanceCriteria")
+    refute_dispatch MiniTest::Spec.spec_type("AcceptanceCriteriaTest")
+    refute_dispatch MiniTest::Spec.spec_type("Acceptance Criteria")
+    refute_dispatch MiniTest::Spec.spec_type("Acceptance Criteria Test")
+    refute_dispatch MiniTest::Spec.spec_type("IntegrationProcess")
+    refute_dispatch MiniTest::Spec.spec_type("IntegrationProcessTest")
+    refute_dispatch MiniTest::Spec.spec_type("Integration Process Test")
+    refute_dispatch MiniTest::Spec.spec_type("IntegrationSolver")
+    refute_dispatch MiniTest::Spec.spec_type("IntegrationSolverTest")
+    refute_dispatch MiniTest::Spec.spec_type("Integration Solver Test")
   end
 end

--- a/test/rails/action_mailer/test_spec_type.rb
+++ b/test/rails/action_mailer/test_spec_type.rb
@@ -26,10 +26,6 @@ class TestActionMailerSpecType < MiniTest::Unit::TestCase
     assert_mailer MiniTest::Spec.spec_type("WidgetMailer")
     assert_mailer MiniTest::Spec.spec_type("WidgetMailerTest")
     assert_mailer MiniTest::Spec.spec_type("Widget Mailer Test")
-    # And is not case sensitive
-    assert_mailer MiniTest::Spec.spec_type("widgetmailer")
-    assert_mailer MiniTest::Spec.spec_type("widgetmailertest")
-    assert_mailer MiniTest::Spec.spec_type("widget mailer test")
   end
 
   def test_spec_type_wont_match_non_space_characters
@@ -38,5 +34,12 @@ class TestActionMailerSpecType < MiniTest::Unit::TestCase
     refute_mailer MiniTest::Spec.spec_type("Widget Mailer\nTest")
     refute_mailer MiniTest::Spec.spec_type("Widget Mailer\fTest")
     refute_mailer MiniTest::Spec.spec_type("Widget MailerXTest")
+  end
+
+  def test_spec_type_wont_match_non_mailer_strings
+    refute_mailer MiniTest::Spec.spec_type("MailerrorTest")
+    refute_mailer MiniTest::Spec.spec_type("MailErrorTest")
+    refute_mailer MiniTest::Spec.spec_type("WidgetMailerWidgetTest")
+    refute_mailer MiniTest::Spec.spec_type("Widget Mailer Widget Test")
   end
 end

--- a/test/rails/action_view/test_spec_type.rb
+++ b/test/rails/action_view/test_spec_type.rb
@@ -16,20 +16,12 @@ class TestActionViewSpecType < MiniTest::Unit::TestCase
     assert_view MiniTest::Spec.spec_type("WidgetHelper")
     assert_view MiniTest::Spec.spec_type("WidgetHelperTest")
     assert_view MiniTest::Spec.spec_type("Widget Helper Test")
-    # And is not case sensitive
-    assert_view MiniTest::Spec.spec_type("widgethelper")
-    assert_view MiniTest::Spec.spec_type("widgethelpertest")
-    assert_view MiniTest::Spec.spec_type("widget helper test")
   end
 
   def test_spec_type_resolves_for_matching_view_strings
     assert_view MiniTest::Spec.spec_type("WidgetView")
     assert_view MiniTest::Spec.spec_type("WidgetViewTest")
     assert_view MiniTest::Spec.spec_type("Widget View Test")
-    # And is not case sensitive
-    assert_view MiniTest::Spec.spec_type("widgetview")
-    assert_view MiniTest::Spec.spec_type("widgetviewtest")
-    assert_view MiniTest::Spec.spec_type("widget view test")
   end
 
   def test_spec_type_wont_match_non_space_characters
@@ -38,5 +30,15 @@ class TestActionViewSpecType < MiniTest::Unit::TestCase
     refute_view MiniTest::Spec.spec_type("Widget Helper\nTest")
     refute_view MiniTest::Spec.spec_type("Widget Helper\fTest")
     refute_view MiniTest::Spec.spec_type("Widget HelperXTest")
+  end
+
+  def test_spec_type_wont_match_non_view_strings
+    refute_view MiniTest::Spec.spec_type("Overview")
+    refute_view MiniTest::Spec.spec_type("OverviewTest")
+    refute_view MiniTest::Spec.spec_type("Overview Test")
+    refute_view MiniTest::Spec.spec_type("Viewer")
+    refute_view MiniTest::Spec.spec_type("ViewerTest")
+    refute_view MiniTest::Spec.spec_type("Viewer Test")
+    refute_view MiniTest::Spec.spec_type("WidgetViewWidgetTest")
   end
 end


### PR DESCRIPTION
Ran into an issue where unit testing a model named NewsOverview resulted in the test being a subclass of MiniTest::Rails::ActionView::TestCase instead of MiniTest::Spec.
We propose to make the spec types case sensitive again.
