### PR TITLE
Enhancements for subclassers of Generators::Base

### DIFF
--- a/lib/generators/mini_test.rb
+++ b/lib/generators/mini_test.rb
@@ -7,6 +7,9 @@ module MiniTest
       class_option :old_style_hash, :type => :boolean, :default => false,
                                     :desc => "Force using old style hash (:foo => 'bar') on Ruby >= 1.9"
 
+      class_option :spec, :type => :boolean, :default => false,
+                          :desc => "Use MiniTest::Spec DSL"
+
       def self.default_source_root
         File.expand_path(File.join(File.dirname(__FILE__), 'mini_test', generator_name, 'templates'))
       end

--- a/lib/generators/mini_test/controller/controller_generator.rb
+++ b/lib/generators/mini_test/controller/controller_generator.rb
@@ -4,7 +4,6 @@ module MiniTest
   module Generators
     class ControllerGenerator < Base
       argument     :actions, :type => :array,   :default => [],    :banner => "action action"
-      class_option :spec,    :type => :boolean, :default => false, :desc   => "Use MiniTest::Spec DSL"
 
       check_class_collision :suffix => "ControllerTest"
 

--- a/lib/generators/mini_test/helper/helper_generator.rb
+++ b/lib/generators/mini_test/helper/helper_generator.rb
@@ -3,8 +3,6 @@ require "generators/mini_test"
 module MiniTest
   module Generators
     class HelperGenerator < Base
-      class_option :spec,    :type => :boolean, :default => false, :desc   => "Use MiniTest::Spec DSL"
-
       check_class_collision :suffix => "HelperTest"
 
       def create_test_files

--- a/lib/generators/mini_test/integration/integration_generator.rb
+++ b/lib/generators/mini_test/integration/integration_generator.rb
@@ -3,8 +3,6 @@ require "generators/mini_test"
 module MiniTest
   module Generators
     class IntegrationGenerator < Base
-      class_option :spec, :type => :boolean, :default => false, :desc => "Use MiniTest::Spec DSL"
-
       check_class_collision :suffix => "Test"
 
       def create_test_files

--- a/lib/generators/mini_test/mailer/mailer_generator.rb
+++ b/lib/generators/mini_test/mailer/mailer_generator.rb
@@ -4,7 +4,6 @@ module MiniTest
   module Generators
     class MailerGenerator < Base
       argument     :actions, :type => :array,   :default => [],    :banner => "method method"
-      class_option :spec,    :type => :boolean, :default => false, :desc => "Use MiniTest::Spec DSL"
 
       check_class_collision :suffix => "MailerTest"
 

--- a/lib/generators/mini_test/model/model_generator.rb
+++ b/lib/generators/mini_test/model/model_generator.rb
@@ -5,7 +5,6 @@ module MiniTest
     class ModelGenerator < Base
       argument     :attributes, :type => :array,   :default => [],    :banner => "field:type field:type"
       class_option :fixture,    :type => :boolean, :default => true,  :desc => "Create fixture file"
-      class_option :spec,       :type => :boolean, :default => false, :desc => "Use MiniTest::Spec DSL"
 
       check_class_collision :suffix => "Test"
 

--- a/lib/generators/mini_test/scaffold/scaffold_generator.rb
+++ b/lib/generators/mini_test/scaffold/scaffold_generator.rb
@@ -6,7 +6,6 @@ module MiniTest
     class ScaffoldGenerator < Base
       include ::Rails::Generators::ResourceHelpers
       argument     :actions, :type => :array,   :default => [],    :banner => "action action"
-      class_option :spec,    :type => :boolean, :default => false, :desc   => "Use MiniTest::Spec DSL"
 
       check_class_collision :suffix => "ControllerTest"
 


### PR DESCRIPTION
When I added the Draper generator, I inherited from `MiniTest::Generators::Base` but had to explicitly define a new [`source_root`](https://github.com/drapergem/draper/blob/master/lib/generators/mini_test/decorator_generator.rb#L6-L8) method.

Normally when inheriting from `Rails::Generator::Base`, you just do `source_root File.expand_path(...)` because the [default implementation](https://github.com/rails/rails/blob/v3.2.11/railties/lib/rails/generators/base.rb#L26-L29) uses the optional argument to set the value, falling back to `default_source_root`.

By changing the currently-hardcoded `source_root` to instead be defined in the `default_source_root`, subclasses can still use `source_root` in the normal way.

Also, I had to specify that the `spec` option was available. Since it's an option on all the generators, I think it makes sense to move it up to `Base` so that subclasses don't have to copy it - and to gently push subclassers to write spec templates as well as test templates :)
