### PR TITLE
Making it possible to write routing tests

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -84,6 +84,7 @@ require "action_dispatch/testing/integration"
 class ActionDispatch::IntegrationTest
   # Register by name, consider Acceptance to be deprecated
   register_spec_type(/(Integration|Acceptance)( ?Test)?\z/i, self)
+  register_spec_type(/routing/i, self)
 end
 
 # Default wiring for the tests. This was originaly done in the helper.

--- a/lib/minitest/rails/testing.rb
+++ b/lib/minitest/rails/testing.rb
@@ -6,7 +6,7 @@ module MiniTest
       mattr_accessor :default_tasks
       mattr_accessor :task_opts
 
-      self.default_tasks = %w(models helpers controllers mailers integration)
+      self.default_tasks = %w(models helpers controllers mailers integration routes)
       self.task_opts = { "performance" => "-- --benchmark" }
 
       def self.all_tasks


### PR DESCRIPTION
Hey man, again.

If you don't mind, I've added the `test/routes` into the list so we could write pure routing tests if we need. And also I've registered the integration test to run tests matching the `'routing'` word in the description
