### PR TITLE
Expose rake tasks for Rails `rake -T` + Organize rake tasks

### DIFF
--- a/lib/minitest/rails/tasks/minitest.rake
+++ b/lib/minitest/rails/tasks/minitest.rake
@@ -2,39 +2,26 @@ require "rake/testtask"
 require "minitest/rails/testing"
 require "minitest/rails/tasks/sub_test_task"
 
-desc "Runs minitest"
-task :test do
-  # Add to existing task if exists, or create new task otherwise
-  Rake::Task["minitest"].invoke
-end
-
 namespace "test" do
   task :prepare do
     # Define here in case test_unit isn't loaded
   end
 end
 
-# desc "Runs default tests (#{MiniTest::Rails::Testing.default_tasks.join(', ')})"
+desc "Runs all tests in test directory"
 task :minitest do
   Rake::Task["minitest:default"].invoke
 end
 
 namespace "minitest" do
 
-  # Only run the default tasks defined in MiniTest::Rails::Testing.default_tasks
   task :default do
-    MiniTest::Rails::Testing.run_tests MiniTest::Rails::Testing.default_tasks
-  end
-
-  # Run all tests in all the test directories
-  # desc "Runs all tests"
-  task :all do
     MiniTest::Rails::Testing.run_tests MiniTest::Rails::Testing.all_tasks
   end
 
   MiniTest::Rails::Testing.all_tasks.each do |task_dir|
     unless Rake::Task.task_defined? "minitest:#{task_dir}"
-      # desc "Runs tests under test/#{task_dir}"
+      desc "Runs tests in test/#{task_dir}"
       MiniTest::Rails::Tasks::SubTestTask.new(task_dir => "test:prepare") do |t|
         t.libs.push "test"
         t.pattern = "test/#{task_dir}/**/*_test.rb"

--- a/lib/minitest/rails/testing.rb
+++ b/lib/minitest/rails/testing.rb
@@ -3,10 +3,8 @@ require "rake/testtask"
 module MiniTest
   module Rails
     module Testing
-      mattr_accessor :default_tasks
       mattr_accessor :task_opts
 
-      self.default_tasks = %w(models helpers controllers mailers integration)
       self.task_opts = { "performance" => "-- --benchmark" }
 
       def self.all_tasks


### PR DESCRIPTION
Currently, the minitest rake tasks are not showing when I do `rake -T` in a Rails project, because the descriptions of the tasks are commented.

Also `rake test`, available in `rake -T`, doesn't actually run all tests upon inspection. 
They only run tests in controllers, helpers, mailers, integration and models. So I have tests in test/lib which were not ran when I do a `rake test`, and that's unexpected.

This commit hopes to fix all these:
- expose rake tasks to `rake -T`in Rails by uncommenting `desc`
- `rake minitest` should run all tasks instead of just default tasks
- remove `default_tasks` as it is obsolete because of `all_tasks`
- remove `rake test` and `rake minitest:all` since they are essentially the same as `rake minitest`
