### PR TITLE
assert_routing should use controller in its options hash, not class

### DIFF
--- a/lib/generators/mini_test/route/templates/route_spec.rb
+++ b/lib/generators/mini_test/route/templates/route_spec.rb
@@ -5,6 +5,6 @@ require "test_helper"
 
 describe "Route Integration Test" do
   it "route root" do
-    assert_routing "/", class: "home", action: "show"
+    assert_routing "/", controller: "home", action: "show"
   end
 end

--- a/lib/generators/mini_test/route/templates/route_test.rb
+++ b/lib/generators/mini_test/route/templates/route_test.rb
@@ -5,6 +5,6 @@ require "test_helper"
 
 class RouteTest < ActionDispatch::IntegrationTest
   def test_root
-    assert_routing "/", class: "home", action: "show"
+    assert_routing "/", controller: "home", action: "show"
   end
 end


### PR DESCRIPTION
`class:` does not exists, `controller:` must be used, see:

http://apidock.com/rails/v3.2.13/ActionDispatch/Assertions/RoutingAssertions/assert_routing
