### PR TITLE
Run load hooks after setting up spec DSL

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -105,6 +105,12 @@ if LoadError.const_defined? :REGEXPS
 end
 
 ################################################################################
+# Run load hooks so that other gems can register spec types
+################################################################################
+
+ActiveSupport.run_load_hooks(:minitest, ActiveSupport::TestCase)
+
+################################################################################
 # Deprecated, for backwards compatibility with older minitest-rails only
 # Will be removed at version 1.0
 ################################################################################


### PR DESCRIPTION
v0.9 slightly broke Draper's integration because we had `require 'minitest/rails'` in order to make sure the Rails `TestCase`s had the spec DSL (we need to `register_spec_type` for decorators). Now that require statement also pulls in `minitest/autorun`, which causes our class to be run, albeit with zero tests.

For other gems to be able to call `register_spec_type`, they need to be able to sneak in after Minitest::Rails works its magic. I think the simplest approach is to provide a load hook.
