### PR TITLE
Alias assert_difference to must_change for ActionController::TestCase

### DIFF
--- a/lib/minitest/rails/expectations.rb
+++ b/lib/minitest/rails/expectations.rb
@@ -635,6 +635,7 @@ unless ENV["MT_NO_EXPECTATIONS"]
     alias :must_select :assert_select
     alias :must_select_email :assert_select_email
     alias :must_select_encoded :assert_select_encoded
+    alias :must_change :assert_difference
   end
   class ActionView::TestCase # :nodoc:
     alias :must_respond_with :assert_response


### PR DESCRIPTION
I'm not sure if this is the correct place to add this but I'd like to be able to use `#must_change` in my controller tests rather than `#assert_difference`.
