### PR TITLE
Use single quotes where escaping is not needed (README)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,11 +21,11 @@ Create a new rails app:
 
 Add <tt>minitest-rails</tt> to the Gemfile:
 
-    gem "minitest-rails"
+    gem 'minitest-rails'
 
 If you are running Rails 4.0 or earlier, be sure to specify a 1.x release in the Gemfile:
 
-    gem "minitest-rails", "~> 1.0"
+    gem 'minitest-rails', '~> 1.0'
 
 Next run the installation generator with the following:
 
@@ -54,20 +54,20 @@ You can also set these as defaults by adding the following to the <tt>config/app
     config.generators do |g|
       g.test_framework :minitest, spec: true, fixture: false
     end
-    
+
 == Running Tests
 
 To run your tests use the <tt>rake test</tt> that ship with rails. For a complete list run <tt>rake -T</tt>.
 
 To add additional testing tasks, define them in your <tt>Rakefile</tt> or a file in <tt>lib/tasks</tt> like so:
 
-    Rails::TestTask.new("test:presenters" => "test:prepare") do |t|
-      t.pattern = "test/presenters/**/*_test.rb"
+    Rails::TestTask.new('test:presenters' => 'test:prepare') do |t|
+      t.pattern = 'test/presenters/**/*_test.rb'
     end
 
 If you want your new task to be run when you run <tt>rake test</tt>, also add the following:
 
-    Rake::Task["test:run"].enhance ["test:presenters"]
+    Rake::Task['test:run'].enhance ['test:presenters']
 
 == Using Rails 4.0 or earlier
 


### PR DESCRIPTION
Slight improvement for the code snippets in the README. Replaces the double quotes with single quotes where escaping is not needed.
