### PR TITLE
Make addl_spec check more permissive

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -33,7 +33,7 @@ class ActiveSupport::TestCase
     end
   end
   register_spec_type(self) do |desc, addl|
-    :model == addl
+    Array(addl).flatten.include? :model
   end
 end
 
@@ -45,7 +45,7 @@ class ActionController::TestCase
   end
   register_spec_type(/Controller( ?Test)?\z/i, self)
   register_spec_type(self) do |desc, addl|
-    :controller == addl
+    Array(addl).flatten.include? :controller
   end
 
   # Resolve the controller from the test name when using the spec DSL
@@ -63,7 +63,8 @@ class ActionView::TestCase
   # Use AV::TestCase for the base class for helpers and views
   register_spec_type(/(Helper( ?Test)?| View Test)\z/i, self)
   register_spec_type(self) do |desc, addl|
-    [ :view, :helper ].include? addl
+    Array(addl).flatten.include?(:view) ||
+    Array(addl).flatten.include?(:helper)
   end
 
   # Resolve the helper or view from the test name when using the spec DSL
@@ -84,7 +85,7 @@ if defined? ActionMailer
     end
     register_spec_type(/Mailer( ?Test)?\z/i, self)
   register_spec_type(self) do |desc, addl|
-    :mailer == addl
+    Array(addl).flatten.include? :mailer
   end
 
     # Resolve the mailer from the test name when using the spec DSL
@@ -103,7 +104,7 @@ class ActionDispatch::IntegrationTest
   # Register by name, consider Acceptance to be deprecated
   register_spec_type(/(Integration|Acceptance)( ?Test)?\z/i, self)
   register_spec_type(self) do |desc, addl|
-    :integration == addl
+    Array(addl).flatten.include? :integration
   end
 end
 
@@ -113,7 +114,7 @@ class Rails::Generators::TestCase
   end
   register_spec_type(/Generator( ?Test)?\z/i, self)
   register_spec_type(self) do |desc, addl|
-    :generator == addl
+    Array(addl).flatten.include? :generator
   end
 
   def self.determine_default_generator(name)

--- a/test/rails/action_controller/test_spec_type.rb
+++ b/test/rails/action_controller/test_spec_type.rb
@@ -35,8 +35,13 @@ class TestApplicationControllerSpecType < Minitest::Test
     refute_controller Minitest::Spec.spec_type("Widget ControllerXTest")
   end
 
-  def test_spec_type_resolves_for_additional_desc_controller
+  def test_spec_type_doesnt_resolve_random_strings
     refute_controller Minitest::Spec.spec_type("Unmatched String")
+  end
+
+  def test_spec_type_resolves_for_additional_desc_controller
     assert_controller Minitest::Spec.spec_type(["Unmatched String", :controller])
+    assert_controller Minitest::Spec.spec_type(["Unmatched String", [:controller, :other]])
+    assert_controller Minitest::Spec.spec_type(["Unmatched String", {controller: true, other: false}])
   end
 end

--- a/test/rails/action_dispatch/test_spec_type.rb
+++ b/test/rails/action_dispatch/test_spec_type.rb
@@ -49,8 +49,13 @@ class TestActionDispatchSpecType < Minitest::Test
     refute_dispatch Minitest::Spec.spec_type("Widget IntegrationXTest")
   end
 
-  def test_spec_type_resolves_for_additional_desc_integration
+  def test_spec_type_doesnt_resolve_random_strings
     refute_dispatch Minitest::Spec.spec_type("Unmatched String")
+  end
+
+  def test_spec_type_resolves_for_additional_desc_integration
     assert_dispatch Minitest::Spec.spec_type(["Unmatched String", :integration])
+    assert_dispatch Minitest::Spec.spec_type(["Unmatched String", [:integration, :other]])
+    assert_dispatch Minitest::Spec.spec_type(["Unmatched String", {integration: true, other: false}])
   end
 end

--- a/test/rails/action_mailer/test_spec_type.rb
+++ b/test/rails/action_mailer/test_spec_type.rb
@@ -35,8 +35,13 @@ class TestActionMailerSpecType < Minitest::Test
     refute_mailer Minitest::Spec.spec_type("Widget MailerXTest")
   end
 
-  def test_spec_type_resolves_for_additional_desc_mailer
+  def test_spec_type_doesnt_resolve_random_strings
     refute_mailer Minitest::Spec.spec_type("Unmatched String")
+  end
+
+  def test_spec_type_resolves_for_additional_desc_mailer
     assert_mailer Minitest::Spec.spec_type(["Unmatched String", :mailer])
+    assert_mailer Minitest::Spec.spec_type(["Unmatched String", [:mailer, :other]])
+    assert_mailer Minitest::Spec.spec_type(["Unmatched String", {mailer: true, other: false}])
   end
 end

--- a/test/rails/action_view/test_spec_type.rb
+++ b/test/rails/action_view/test_spec_type.rb
@@ -40,9 +40,19 @@ class TestActionViewSpecType < Minitest::Test
     refute_view Minitest::Spec.spec_type("Widget HelperXTest")
   end
 
-  def test_spec_type_resolves_for_additional_desc_view_or_helper
+  def test_spec_type_doesnt_resolve_random_strings
     refute_view Minitest::Spec.spec_type("Unmatched String")
+  end
+
+  def test_spec_type_resolves_for_additional_desc_view
     assert_view Minitest::Spec.spec_type(["Unmatched String", :view])
+    assert_view Minitest::Spec.spec_type(["Unmatched String", [:view, :other]])
+    assert_view Minitest::Spec.spec_type(["Unmatched String", {view: true, other: false}])
+  end
+
+  def test_spec_type_resolves_for_additional_desc_helper
     assert_view Minitest::Spec.spec_type(["Unmatched String", :helper])
+    assert_view Minitest::Spec.spec_type(["Unmatched String", [:helper, :other]])
+    assert_view Minitest::Spec.spec_type(["Unmatched String", {helper: true, other: false}])
   end
 end

--- a/test/rails/active_support/test_spec_type.rb
+++ b/test/rails/active_support/test_spec_type.rb
@@ -22,5 +22,7 @@ class TestActiveSupportSpecType < Minitest::Test
 
   def test_spec_type_resolves_for_additional_desc_model
     assert_support Minitest::Spec.spec_type(["Unmatched String", :model])
+    assert_support Minitest::Spec.spec_type(["Unmatched String", [:model, :other]])
+    assert_support Minitest::Spec.spec_type(["Unmatched String", {model: true, other: false}])
   end
 end

--- a/test/rails/generators/test_spec_type.rb
+++ b/test/rails/generators/test_spec_type.rb
@@ -32,4 +32,14 @@ class TestGeneratorsSpecType < Minitest::Test
     refute_generator Minitest::Spec.spec_type("Install Generator\fTest")
     refute_generator Minitest::Spec.spec_type("Install GeneratorXTest")
   end
+
+  def test_spec_type_doesnt_resolve_random_strings
+    refute_generator Minitest::Spec.spec_type("Unmatched String")
+  end
+
+  def test_spec_type_resolves_for_additional_desc_generator
+    assert_generator Minitest::Spec.spec_type(["Unmatched String", :generator])
+    assert_generator Minitest::Spec.spec_type(["Unmatched String", [:generator, :other]])
+    assert_generator Minitest::Spec.spec_type(["Unmatched String", {generator: true, other: false}])
+  end
 end


### PR DESCRIPTION
Folks may want to list several items in the addl_spec object,
so support arrays and hashes in the check.

This change allows you to create a test like so:

```
describe NotAnActiveRecordClass, [ :scope_of_test, :model ] do
```

Or, like this:

```
describe NotAnActiveRecordClass, scope: :update, model: true do
```
