### PR TITLE
Fixed scaffold generator so that it will pass on unchanged scaffolding.

### DIFF
--- a/lib/generators/minitest/scaffold/scaffold_generator.rb
+++ b/lib/generators/minitest/scaffold/scaffold_generator.rb
@@ -29,7 +29,7 @@ module Minitest
           if %w(password password_confirmation).include?(name) && attributes.any?(&:password_digest?)
             "#{name}: 'secret'"
           else
-            "#{name}: @#{singular_table_name}.#{name}"
+            "#{name}: #{singular_table_name}.#{name}"
           end
         end.sort.join(", ")
       end

--- a/test/generators/test_scaffold_generator.rb
+++ b/test/generators/test_scaffold_generator.rb
@@ -5,20 +5,22 @@ class TestScaffoldGenerator < GeneratorTest
 
   def test_scaffold_generator
     assert_output(/create  test\/controllers\/users_controller_test.rb/m) do
-      Minitest::Generators::ScaffoldGenerator.start ["user"]
+      Minitest::Generators::ScaffoldGenerator.start ["User", "name:string", "email:string"]
     end
     assert File.exists? "test/controllers/users_controller_test.rb"
     contents = File.read "test/controllers/users_controller_test.rb"
     assert_match(/class UsersControllerTest/m, contents)
+    assert_match(/post :create, user: { email: user.email, name: user.name }/m, contents)
   end
 
   def test_scaffold_generator_spec
     assert_output(/create  test\/controllers\/users_controller_test.rb/m) do
-      Minitest::Generators::ScaffoldGenerator.start ["user", "--spec"]
+      Minitest::Generators::ScaffoldGenerator.start ["User", "name:string", "email:string", "--spec"]
     end
     assert File.exists? "test/controllers/users_controller_test.rb"
     contents = File.read "test/controllers/users_controller_test.rb"
     assert_match(/describe UsersController do/m, contents)
+    assert_match(/post :create, user: { email: user.email, name: user.name }/m, contents)
   end
 
 end


### PR DESCRIPTION
Controller Test Generators were calling @instance variables for the table name despite the fact that it was defined as a singular method:

``` ruby
let(:car) { cars :one }
@car.make
```

NoMethodError: undefined method `make' for nil:NilClass

I fixed them to be the same.
