### PR TITLE
Fix `MT_NO_EXPECTATIONS` example template

### DIFF
--- a/lib/generators/minitest/install/templates/test/test_helper.rb.tt
+++ b/lib/generators/minitest/install/templates/test/test_helper.rb.tt
@@ -4,7 +4,7 @@ require "rails/test_help"
 require "minitest/rails"
 
 # Consider setting MT_NO_EXPECTATIONS to not add expectations to Object.
-# ENV["MT_NO_EXPECTATIONS"] = true
+# ENV["MT_NO_EXPECTATIONS"] = 'true'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers

--- a/lib/generators/minitest/install/templates/test/test_helper.rb.tt
+++ b/lib/generators/minitest/install/templates/test/test_helper.rb.tt
@@ -4,7 +4,7 @@ require "rails/test_help"
 require "minitest/rails"
 
 # Consider setting MT_NO_EXPECTATIONS to not add expectations to Object.
-# ENV["MT_NO_EXPECTATIONS"] = 'true'
+# ENV["MT_NO_EXPECTATIONS"] = "true"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
If this line is simply uncommented it will result in code like this:
```
ENV["MT_NO_EXPECTATIONS"] = true
(irb):1:in `[]=': no implicit conversion of true into String (TypeError)
        from (irb):1:in `<main>'
        from /home/lobashov/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /home/lobashov/.rbenv/versions/3.1.2/bin/irb:25:in `load'
        from /home/lobashov/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'
```
Value of this ENV should be not empty, so any string value is good to go