### PR TITLE
Make the project rails 7.1 compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,9 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         gemfile:
-          - gemfiles/rails-7.0.0.gemfile
+          - gemfiles/rails-7.1.0.gemfile
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
@@ -55,7 +56,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+### 7.1.0 / 2023-10-09
+
+Support Rails 7.1.
+
 ### 7.0.0 / 2022-04-25
 
 Support Rails 7.0.

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "http://rubygems.org"
 gemspec
 
 gem "irb"
-gem "rails", "~> 7.0.0"
+gem "rails", "~> 7.1.0"
 gem "rake"
 gem "sqlite3"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Create a new rails app:
 ### Choosing a version
 
 This gem follows the versioning of Rails.
-If you are running Rails 7.0, specify the corresponding 7.0 release in the Gemfile.
+If you are running Rails 7.1, specify the corresponding 7.1 release in the Gemfile.
 For example:
 
 ```ruby
-gem "minitest-rails", "~> 7.0.0"
+gem "minitest-rails", "~> 7.1.0"
 ```
 
 If you are running Rails 6.x, specify the corresponding 6.x release in the Gemfile.

--- a/gemfiles/rails-7.1.0.gemfile
+++ b/gemfiles/rails-7.1.0.gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "minitest-rails", path: "../"
-gem "rails", "~> 7.0.0"
+gem "rails", "~> 7.1.0"
 gem "rake"
 gem "sqlite3"
 

--- a/lib/minitest/rails/version.rb
+++ b/lib/minitest/rails/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Rails
-    VERSION = "7.0.0".freeze
+    VERSION = "7.1.0".freeze
   end
 end

--- a/minitest-rails.gemspec
+++ b/minitest-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "minitest", "~> 5.10"
-  gem.add_dependency "railties", "~> 7.0.0"
+  gem.add_dependency "railties", "~> 7.1.0"
 
   gem.add_development_dependency "minitest-autotest", "~> 1.1"
   gem.add_development_dependency "minitest-focus", "~> 1.3"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,7 +21,6 @@ end
 require "action_mailer"
 
 require "minitest-rails"
-require "rails/test_help"
 require "minitest/rails"
 
 require "minitest/focus"
@@ -49,6 +48,7 @@ module TestApp
     config.secret_key_base = "abc123"
     config.hosts << "www.example.com"
     config.eager_load = false
+    config.load_defaults 7.1
   end
 end
 
@@ -109,7 +109,7 @@ require "action_view"
 ActionMailer::Base.include(ActionView::Layouts)
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
+Rails.application.deprecators.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/test/rails/action_dispatch/test_expectations.rb
+++ b/test/rails/action_dispatch/test_expectations.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "rails/test_help"
 
 class TestIntegrationExpectations < ActionDispatch::IntegrationTest
   def test_must_respond_with


### PR DESCRIPTION
I've made the following changes to get the project running on a rails 7.1 project.
Aside from the changes, I've also included ruby 3.1 in the CI matrix: https://github.com/manuelvanrijn/minitest-rails/actions/runs/6459990864

Hope this helps to get the project in shape for this new rails version :)

Fixes #249 