### PR TITLE
Bump action checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -51,7 +51,7 @@ jobs:
         || contains(github.event.pull_request.title,  '[skip ci]'))
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
I've noticed the warnings: `The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2` while creating my other PR. I didn't found these changes relevant so included a separate pull request for this.

<img width="844" alt="Screenshot 2023-10-09 at 19 48 03" src="https://github.com/minitest/minitest-rails/assets/331876/d91ad2dc-2263-4bcf-ba76-3035fa1e291f">
