### PR TITLE
Support Rails 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
           - '3.3'
         gemfile:
           - gemfiles/rails-7.1.0.gemfile
-          - gemfiles/rails-7.2.0.beta2.gemfile
+          - gemfiles/rails-7.2.0.gemfile
         exclude:
           - ruby: '2.7'
-            gemfile: gemfiles/rails-7.2.0.beta2.gemfile
+            gemfile: gemfiles/rails-7.2.0.gemfile
           - ruby: '3.0'
-            gemfile: gemfiles/rails-7.2.0.beta2.gemfile
+            gemfile: gemfiles/rails-7.2.0.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+### 7.2.0 / 2024-08-30
+
+Support Rails 7.2.
+
 ### 7.1.0 / 2023-10-26
 
 Support Rails 7.1.

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "http://rubygems.org"
 gemspec
 
 gem "irb"
-gem "rails", "~> 7.1.0"
+gem "rails", "~> 7.2.0"
 gem "rake"
 gem "sqlite3", "~> 1.4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minitest-rails
 
-Minitest integration for Rails 7.1
+Minitest integration for Rails 7.2
 
 [![CI](https://github.com/minitest/minitest-rails/actions/workflows/ci.yml/badge.svg)](https://github.com/minitest/minitest-rails/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/minitest/minitest-rails/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/minitest/minitest-rails/actions/workflows/github-code-scanning/codeql)
@@ -22,7 +22,13 @@ Create a new rails app:
 ### Choosing a version
 
 This gem follows the versioning of Rails.
-For example, if you are using Rails 7.1 you will specify:
+For example, if you are using Rails 7.2 you will specify:
+
+```ruby
+gem "minitest-rails", "~> 7.2.0"
+```
+
+If you are running Rails 7.1 you will specify:
 
 ```ruby
 gem "minitest-rails", "~> 7.1.0"

--- a/gemfiles/rails-7.2.0.gemfile
+++ b/gemfiles/rails-7.2.0.gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "minitest-rails", path: "../"
-gem "rails", "7.2.0.beta2"
+gem "rails", "~> 7.2.0"
 gem "rake"
 gem "sqlite3", "~> 1.4"
 

--- a/lib/minitest/rails/assertions/action_cable.rb
+++ b/lib/minitest/rails/assertions/action_cable.rb
@@ -25,7 +25,7 @@ class ActionCable::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::TestHelper#must_have_broadcasts
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_broadcasts
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_broadcasts
   #
   # :method: assert_broadcasts
   # :call-seq: assert_broadcasts(stream, number)
@@ -52,7 +52,7 @@ class ActionCable::TestCase
   #   assert_broadcasts 'messages', 0, &block
   #
   # See also Minitest::Rails::Expectations::ActionCable::TestHelper#wont_have_broadcasts
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_no_broadcasts
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_no_broadcasts
   #
   # :method: refute_broadcasts
   # :call-seq: refute_broadcasts(stream, &block)
@@ -75,7 +75,7 @@ class ActionCable::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::TestHelper#must_broadcast_on
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_broadcast_on
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_broadcast_on
   #
   # :method: assert_broadcast_on
   # :call-seq: assert_broadcast_on(stream, data)
@@ -108,7 +108,7 @@ class ActionCable::Channel::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::TestHelper#must_have_broadcasts
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_broadcasts
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_broadcasts
   #
   # :method: assert_broadcasts
   # :call-seq: assert_broadcasts(stream, number)
@@ -135,7 +135,7 @@ class ActionCable::Channel::TestCase
   #   assert_broadcasts 'messages', 0, &block
   #
   # See also Minitest::Rails::Expectations::ActionCable::TestHelper#wont_have_broadcasts
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_no_broadcasts
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_no_broadcasts
   #
   # :method: refute_broadcasts
   # :call-seq: refute_broadcasts(stream, &block)
@@ -158,7 +158,7 @@ class ActionCable::Channel::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::TestHelper#must_broadcast_on
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_broadcast_on
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_broadcast_on
   #
   # :method: assert_broadcast_on
   # :call-seq: assert_broadcast_on(stream, data)
@@ -172,7 +172,7 @@ class ActionCable::Channel::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::Channel#wont_have_streams
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_no_streams
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_no_streams
   #
   # :method: refute_streams
   alias refute_streams assert_no_streams
@@ -186,7 +186,7 @@ class ActionCable::Channel::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::Channel#must_have_streams
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream
   #
   # :method: assert_has_stream
   # :call-seq: assert_has_stream(stream)
@@ -200,7 +200,7 @@ class ActionCable::Channel::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable::Channel#must_have_stream_for
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream_for
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream_for
   #
   # :method: assert_has_stream_for
   # :call-seq: assert_has_stream_for(object)
@@ -226,7 +226,7 @@ class ActionCable::Connection::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionCable#must_reject_connection
-  # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Connection/Assertions.html#method-i-assert_reject_connection
+  # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Connection/Assertions.html#method-i-assert_reject_connection
   #
   # :method: assert_reject_connection
 end

--- a/lib/minitest/rails/assertions/action_mailer.rb
+++ b/lib/minitest/rails/assertions/action_mailer.rb
@@ -25,7 +25,7 @@ class ActionMailer::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionMailer#must_have_emails
-  # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_emails
+  # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_emails
   #
   # :method: assert_emails
   # :call-seq: assert_emails(number, &block)
@@ -51,7 +51,7 @@ class ActionMailer::TestCase
   #   assert_emails 0, &block
   #
   # See also Minitest::Rails::Expectations::ActionMailer#wont_have_emails
-  # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_no_emails
+  # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_no_emails
   #
   # :method: refute_emails
   # :call-seq: refute_emails(&block)
@@ -84,7 +84,7 @@ class ActionMailer::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionMailer#must_have_enqueued_emails
-  # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_emails
+  # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_emails
   #
   # :method: assert_enqueued_emails
   # :call-seq: assert_enqueued_emails(number, &block)
@@ -122,7 +122,7 @@ class ActionMailer::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionMailer#must_enqueue_email_with
-  # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_email_with
+  # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_email_with
   #
   # :method: assert_enqueued_email_with
   # :call-seq: assert_enqueued_email_with(mailer, method, args: nil, queue: "mailers", &block)
@@ -145,7 +145,7 @@ class ActionMailer::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActionMailer#wont_have_enqueued_emails
-  # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_no_enqueued_emails
+  # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_no_enqueued_emails
   #
   # :method: refute_enqueued_emails
   # :call-seq: refute_enqueued_emails(&block)

--- a/lib/minitest/rails/assertions/active_support.rb
+++ b/lib/minitest/rails/assertions/active_support.rb
@@ -8,7 +8,7 @@ class ActiveSupport::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActiveSupport#must_change
-  # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_changes
+  # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_changes
   #
   # :method: assert_changes
   # :call-seq: assert_changes(expression, message = nil, from: UNTRACKED, to: UNTRACKED, &block)
@@ -22,7 +22,7 @@ class ActiveSupport::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActiveSupport#wont_change
-  # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_changes
+  # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_changes
   #
   # :args: expression, message = nil, &block
   alias refute_changes assert_no_changes
@@ -36,7 +36,7 @@ class ActiveSupport::TestCase
   #     end
   #
   # See also Minitest::Rails::Expectations::ActiveSupport#must_change
-  # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_difference
+  # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_difference
   #
   # :method: assert_difference
   # :call-seq: assert_difference(expression, *args, &block)
@@ -50,7 +50,7 @@ class ActiveSupport::TestCase
   #   end
   #
   # See also Minitest::Rails::Expectations::ActiveSupport#wont_change
-  # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_difference
+  # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_difference
   #
   # :args: expression, message = nil, &block
   alias refute_difference assert_no_difference

--- a/lib/minitest/rails/expectations/action_cable.rb
+++ b/lib/minitest/rails/expectations/action_cable.rb
@@ -31,7 +31,7 @@ module Minitest
           #   end
           #
           # See also ActionCable::TestHelper#assert_broadcasts
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_broadcasts
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_broadcasts
           #
           # :method: must_have_broadcasts
           # :call-seq: must_have_broadcasts(stream, number)
@@ -58,7 +58,7 @@ module Minitest
           #   must_have_broadcasts 'messages', 0, &block
           #
           # See also ActionCable::TestHelper#wont_have_broadcasts
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_no_broadcasts
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_no_broadcasts
           #
           # :method: wont_have_broadcasts
           # :call-seq: wont_have_broadcasts(stream, &block)
@@ -80,7 +80,7 @@ module Minitest
           #   end
           #
           # See also ActionCable::TestHelper#assert_broadcast_on
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/TestHelper.html#method-i-assert_broadcast_on
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/TestHelper.html#method-i-assert_broadcast_on
           #
           # :method: must_broadcast_on
           # :call-seq: must_broadcast_on(stream, data)
@@ -104,7 +104,7 @@ module Minitest
           #   end
           #
           # See also ActionCable::Channel::TestCase#assert_no_streams
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_no_streams
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_no_streams
           #
           # :method: wont_have_streams
 
@@ -117,7 +117,7 @@ module Minitest
           #   end
           #
           # See also ActionCable::Channel::TestCase#assert_has_stream
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream
           #
           # :method: must_have_streams
           # :call-seq: must_have_streams(stream)
@@ -131,7 +131,7 @@ module Minitest
           #   end
           #
           # See also ActionCable::Channel::TestCase#assert_has_stream_for
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream_for
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Channel/TestCase/Behavior.html#method-i-assert_has_stream_for
           #
           # :method: must_have_stream_for
           # :call-seq: must_have_stream_for(object)
@@ -166,7 +166,7 @@ module Minitest
           #   end
           #
           # See also ActionCable::Connection::TestCase#assert_reject_connection
-          # See https://api.rubyonrails.org/v7.1/classes/ActionCable/Connection/Assertions.html#method-i-assert_reject_connection
+          # See https://api.rubyonrails.org/v7.2/classes/ActionCable/Connection/Assertions.html#method-i-assert_reject_connection
           #
           # :method: must_reject_connection
 

--- a/lib/minitest/rails/expectations/action_mailer.rb
+++ b/lib/minitest/rails/expectations/action_mailer.rb
@@ -30,7 +30,7 @@ module Minitest
         #   end
         #
         # See also ActionMailer::TestClass#assert_emails
-        # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_emails
+        # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_emails
         #
         # :method: must_have_emails
         # :call-seq: must_have_emails(number, &block)
@@ -56,7 +56,7 @@ module Minitest
         #   must_have_emails 0, &block
         #
         # See also ActionMailer::TestClass#wont_have_emails
-        # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_no_emails
+        # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_no_emails
         #
         # :method: wont_have_emails
         # :call-seq: wont_have_emails(&block)
@@ -88,7 +88,7 @@ module Minitest
         #   end
         #
         # See also ActionMailer::TestClass#assert_enqueued_emails
-        # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_emails
+        # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_emails
         #
         # :method: must_have_enqueued_emails
         # :call-seq: must_have_enqueued_emails(number, &block)
@@ -126,7 +126,7 @@ module Minitest
         #   end
         #
         # See also ActionMailer::TestClass#assert_enqueued_email_with
-        # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_email_with
+        # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_enqueued_email_with
         #
         # :method: must_enqueue_email_with
         # :call-seq: must_enqueue_email_with(mailer, method, args: nil, queue: "mailers", &block)
@@ -149,7 +149,7 @@ module Minitest
         #   end
         #
         # See also ActionMailer::TestClass#assert_no_enqueued_emails
-        # See https://api.rubyonrails.org/v7.1/classes/ActionMailer/TestHelper.html#method-i-assert_no_enqueued_emails
+        # See https://api.rubyonrails.org/v7.2/classes/ActionMailer/TestHelper.html#method-i-assert_no_enqueued_emails
         #
         # :method: wont_have_enqueued_emails
         # :call-seq: wont_have_enqueued_emails(&block)

--- a/lib/minitest/rails/expectations/active_support.rb
+++ b/lib/minitest/rails/expectations/active_support.rb
@@ -12,7 +12,7 @@ module Minitest
         #             end }.must_change "User.count", from: 5, to: 8
         #
         # See also ActiveSupport::TestCase#assert_difference
-        # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_changes
+        # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_changes
         #
         # :method: must_change
         # :args: expression, from: UNTRACKED, to: UNTRACKED
@@ -27,7 +27,7 @@ module Minitest
         #   end
         #
         # See also ActiveSupport::TestCase#assert_difference
-        # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_changes
+        # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_changes
         #
         # :method: wont_change
         # :args: expression
@@ -43,7 +43,7 @@ module Minitest
         #             end }.must_differ "User.count", 3
         #
         # See also ActiveSupport::TestCase#assert_difference
-        # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_difference
+        # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_difference
         #
         # :method: must_differ
         # :args: expression, *args
@@ -56,7 +56,7 @@ module Minitest
         #     value { User.new }.wont_differ "User.count"
         #
         # See also ActiveSupport::TestCase#refute_difference
-        # See https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_difference
+        # See https://api.rubyonrails.org/v7.2/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_no_difference
         #
         # :method: wont_differ
         # :args: expression

--- a/lib/minitest/rails/version.rb
+++ b/lib/minitest/rails/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Rails
-    VERSION = "7.1.1".freeze
+    VERSION = "7.2.0".freeze
   end
 end

--- a/minitest-rails.gemspec
+++ b/minitest-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "minitest", "~> 5.20"
-  gem.add_dependency "railties", ">= 7.1.0", "< 8.0.0"
+  gem.add_dependency "railties", ">= 7.2.0", "< 8.0.0"
 
   gem.add_development_dependency "minitest-autotest", "~> 1.1"
   gem.add_development_dependency "minitest-focus", "~> 1.4"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,7 +26,7 @@ module TestApp
     config.secret_key_base = "abc123"
     config.hosts << "www.example.com"
     config.eager_load = false
-    config.load_defaults 7.1
+    config.load_defaults 7.2
   end
 end
 


### PR DESCRIPTION
Support Rails 7.2

[Rails 7.2](https://github.com/rails/rails/releases/tag/v7.2.0) was released a few weeks ago. This PR upgrades minitest-rails accordingly.

Note that Rails 7.2 bumped the minimum Ruby version from 2.7 to 3.1, so I've done the same here.