### PR TITLE
Fix CI by correcting railties version to include 7.1.z

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
 
       - name: rubocop

--- a/minitest-rails.gemspec
+++ b/minitest-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "minitest", "~> 5.20"
-  gem.add_dependency "railties", ">= 7.2.0", "< 8.0.0"
+  gem.add_dependency "railties", ">= 7.1.0", "< 8.0.0"
 
   gem.add_development_dependency "minitest-autotest", "~> 1.1"
   gem.add_development_dependency "minitest-focus", "~> 1.4"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,7 +26,7 @@ module TestApp
     config.secret_key_base = "abc123"
     config.hosts << "www.example.com"
     config.eager_load = false
-    config.load_defaults 7.2
+    config.load_defaults 7.1
   end
 end
 


### PR DESCRIPTION
Fixes breakage caused by last PR that activated 7.2... this should loosen up the CI to work again