### PR TITLE
Add ruby 4.0 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
         gemfile:
           - gemfiles/rails-8.1.0.gemfile
     env:


### PR DESCRIPTION
I have not tested this locally, so waiting on judgement from CI. It seems like a prudent thing to add.