### PR TITLE
minitest 5->6 upgrade

### DIFF
--- a/minitest-rails.gemspec
+++ b/minitest-rails.gemspec
@@ -17,13 +17,14 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "minitest", "~> 5.20"
+  gem.add_dependency "minitest", "~> 6.0.1"
   gem.add_dependency "railties", ">= 8.1.0", "< 8.2.0"
 
-  gem.add_development_dependency "minitest-autotest", "~> 1.1"
+  gem.add_development_dependency "minitest-autotest", "~> 1.2"
   gem.add_development_dependency "minitest-focus", "~> 1.4"
+  gem.add_development_dependency "minitest-mock", "~> 5.27"
   gem.add_development_dependency "minitest-rg", "~> 5.3"
-  gem.add_development_dependency "rdoc", "~> 6.14"
-  gem.add_development_dependency "rubocop", "~> 1.81.0"
+  gem.add_development_dependency "rdoc", "~> 7.0"
+  gem.add_development_dependency "rubocop", "~> 1.81"
   gem.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Necessary but not sufficient changes. Locally I'm seeing these errors:

```
  1) Error:
TestIntegrationExpectations#test_routing_expectations:
NoMethodError: undefined method 'must_route_to' for an instance of Minitest::Expectation
    test/rails/action_dispatch/test_expectations.rb:18:in 'TestIntegrationExpectations#test_routing_expectations'

  2) Error:
TestIntegrationExpectations#test_must_dom_equal:
NoMethodError: undefined method 'must_dom_equal' for an instance of Minitest::Expectation
    test/rails/action_dispatch/test_expectations.rb:28:in 'TestIntegrationExpectations#test_must_dom_equal'
```

I hope this is in some way helpful, I don't know enough of the internals to easily refine the PR further.